### PR TITLE
Add face detection

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,6 @@ class HomeController < ApplicationController
   end
 
   def show
-    byebug
+
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,5 +6,6 @@ class HomeController < ApplicationController
   end
 
   def show
+    # binding.pry
   end
 end

--- a/app/models/slack_pic.rb
+++ b/app/models/slack_pic.rb
@@ -1,0 +1,3 @@
+class SlackPic < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/slack_pic_creation.rb
+++ b/app/models/slack_pic_creation.rb
@@ -1,0 +1,23 @@
+class SlackPicCreation
+  attr_reader :slack_data, :user
+
+  def initialize(user, slack_data)
+    @user = user
+    @slack_data = slack_data
+  end
+
+  def create
+
+    user.slack_pics.create(
+    face_id: slack_data['face'][0]['face_id'],
+    height: slack_data['face'][0]['position']['height'],
+    width: slack_data['face'][0]['position']['width'],
+    mouth_left_x: slack_data['face'][0]['position']['mouth_left']['x'],
+    mouth_left_y: slack_data['face'][0]['position']['mouth_left']['y'],
+    mouth_right_x: slack_data['face'][0]['position']['mouth_right']['x'],
+    mouth_right_y: slack_data['face'][0]['position']['mouth_right']['y'],
+    nose_x: slack_data['face'][0]['position']['nose']['x'],
+    nose_y: slack_data['face'][0]['position']['nose']['y']
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ActiveRecord::Base
     user.save!
     user
   end
+
+  def send_for_face_detection
+
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
+  has_many :slack_pics
 
   def self.from_omniauth(auth_hash)
     user = find_or_create_by(uid: auth_hash['uid'], provider: auth_hash['provider'])
@@ -6,10 +7,13 @@ class User < ActiveRecord::Base
     user.image_url = auth_hash['extra']['user_info']['user']['profile']['image_1024']
     user.token = auth_hash['credentials']['token']
     user.save!
+    user.send_for_face_detection
     user
   end
 
   def send_for_face_detection
-
+    fpps = FacePlusPlusService.new(self)
+    face_data = fpps.detect_face
+    SlackPicCreation.new(self, face_data).create
   end
 end

--- a/app/services/face_plus_plus_service.rb
+++ b/app/services/face_plus_plus_service.rb
@@ -1,0 +1,29 @@
+class FacePlusPlusService
+  attr_reader :connection, :user
+
+  def initialize(user)
+    @connection ||= Faraday.new(url: "apius.faceplusplus.com/") do |faraday|
+      faraday.request :url_encoded
+      faraday.headers['Content-Type'] = 'application/json'
+      faraday.adapter Faraday.default_adapter
+    end
+    @user = user
+
+    add_token_to_headers
+  end
+
+  def detect_face
+    parse(connection.get("detection/detect", include_tokens))
+  end
+
+
+  private
+
+  def parse(response)
+    JSON.parse(response.body, symbolize_name: true)
+  end
+
+  def include_tokens
+    {api_key: ENV['FACE_KEY'], api_secret: ENV['FACE_SECRET']}
+  end
+end

--- a/app/services/face_plus_plus_service.rb
+++ b/app/services/face_plus_plus_service.rb
@@ -2,18 +2,16 @@ class FacePlusPlusService
   attr_reader :connection, :user
 
   def initialize(user)
-    @connection ||= Faraday.new(url: "apius.faceplusplus.com/") do |faraday|
+    @connection ||= Faraday.new(url: "http://apius.faceplusplus.com/") do |faraday|
       faraday.request :url_encoded
       faraday.headers['Content-Type'] = 'application/json'
       faraday.adapter Faraday.default_adapter
     end
     @user = user
-
-    add_token_to_headers
   end
 
   def detect_face
-    parse(connection.get("detection/detect", include_tokens))
+    parse(connection.get("detection/detect", mode: "oneface", api_key: ENV['FACE_KEY'], api_secret: ENV['FACE_SECRET'], url: user.image_url))
   end
 
 

--- a/db/migrate/20160302172213_create_slack_pics.rb
+++ b/db/migrate/20160302172213_create_slack_pics.rb
@@ -1,0 +1,18 @@
+class CreateSlackPics < ActiveRecord::Migration
+  def change
+    create_table :slack_pics do |t|
+      t.references :user, index: true, foreign_key: true
+      t.string :face_id
+      t.decimal :height
+      t.decimal :width
+      t.decimal :mouth_left_x
+      t.decimal :mouth_left_y
+      t.decimal :mouth_right_x
+      t.decimal :mouth_right_y
+      t.decimal :nose_x
+      t.decimal :nose_y
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301142812) do
+ActiveRecord::Schema.define(version: 20160302172213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "slack_pics", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "face_id"
+    t.decimal  "height"
+    t.decimal  "width"
+    t.decimal  "mouth_left_x"
+    t.decimal  "mouth_left_y"
+    t.decimal  "mouth_right_x"
+    t.decimal  "mouth_right_y"
+    t.decimal  "nose_x"
+    t.decimal  "nose_y"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "slack_pics", ["user_id"], name: "index_slack_pics_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "provider"
@@ -26,4 +43,5 @@ ActiveRecord::Schema.define(version: 20160301142812) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "slack_pics", "users"
 end

--- a/spec/features/guest_can_log_in_through_slack_spec.rb
+++ b/spec/features/guest_can_log_in_through_slack_spec.rb
@@ -1,18 +1,29 @@
 require "rails_helper"
 
 describe "guest can login through slack" do
-  it "sees dashboard with their slack info"  do
-    VCR.use_cassette("slack_service#dashboard") do
+  it "creates user and associated slack picture"  do
+    VCR.use_cassette("slack_login_and_face_detection") do
       visit root_path
       expect(page).to have_content "Stachify"
 
       click_on "Stachify"
 
       user = User.last
+      slack_pic = user.slack_pics.last
 
       expect(current_path).to eq(user_path)
       expect(user.name).to eq "Dan Winter"
       expect(user.image_url).to eq "https://avatars.slack-edge.com/2016-03-01/23827508289_8e0c5fc47896904c9086_1024.jpg"
+
+      expect(slack_pic.face_id).to eq "b7fe4d1710cc81f4baaa41f1bbbf653c"
+      expect(slack_pic.height.to_f).to eq 30.5
+      expect(slack_pic.width.to_f).to eq 30.5
+      expect(slack_pic.mouth_left_x.to_f).to eq 47.079667
+      expect(slack_pic.mouth_left_y.to_f).to eq 52.8425
+      expect(slack_pic.mouth_right_x.to_f).to eq 58.918833
+      expect(slack_pic.mouth_right_y.to_f).to eq 51.746167
+      expect(slack_pic.nose_x.to_f).to eq 54.1085
+      expect(slack_pic.nose_y.to_f).to eq 44.944
     end
   end
 end

--- a/spec/models/slack_pic_spec.rb
+++ b/spec/models/slack_pic_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SlackPic, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Add Face Plus Plus Service for detection/detect. This endpoint gathers basic information about the picture and face location. During user creation, the user's slack image url is sent to the Face Plus Plus service and the returning JSON is parsed and entered into the database as a SlackPic associated to the user.
